### PR TITLE
Drag&drop

### DIFF
--- a/Visualizer/Assets/Scenes/D&D.unity
+++ b/Visualizer/Assets/Scenes/D&D.unity
@@ -3706,6 +3706,7 @@ MonoBehaviour:
   selectionMaterial: {fileID: 2100000, guid: fae19271202dc6f44a39e0ec19b3750b, type: 2}
   runtimeHierarchy: {fileID: 1012258769}
   sceneCamera: {fileID: 0}
+  materialDragHandler: {fileID: 0}
 --- !u!4 &732847828
 Transform:
   m_ObjectHideFlags: 0
@@ -6283,6 +6284,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   materialToApply: {fileID: 2100000, guid: 074db27c79b351845bd462e4d98361c3, type: 2}
+  selectTransformGizmo: {fileID: 0}
 --- !u!61 &1068633443
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Visualizer/Assets/Scripts/MaterialDragHandler.cs
+++ b/Visualizer/Assets/Scripts/MaterialDragHandler.cs
@@ -1,30 +1,47 @@
+using System.Windows.Forms;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.TextBox;
 
 /// <summary>
-/// Permite arrastrar materiales y soltarlos sobre un modelo para aplicar el material.
+/// Permite arrastrar materiales y soltarlos sobre un modelo para aplicar el material ademas se comunica con SelectTransformGizmo para un buen funcionamiento entre ambos.
 /// </summary>
 public class MaterialDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
 {
     public Material materialToApply; // Material que se aplicará al soltar
+    public SelectTransformGizmo selectTransformGizmo; // Referencia al script SelectTransformGizmo
     private Camera mainCamera;
-    private Image materialImage; // Imagen del material para representar visualmente el arrastre
-    private RectTransform rectTransform;
+    private Image materialImage; // Imagen del material para representar visualmente el arrastre en el canvas
+    private RectTransform rectTransform; // Componente de la imagen que controla la posición y el tamaño
     private Vector3 originalScale; // Escala original de la imagen
     private Vector3 originalPosition; // Posición original de la imagen
 
-    private void Start()
+    private void Awake()
     {
-        mainCamera = Camera.main;
-        materialImage = GetComponent<Image>(); // Obtener el componente Image del GameObject
-        rectTransform = GetComponent<RectTransform>();
-        originalScale = rectTransform.localScale;
-        originalPosition = rectTransform.position; // Guardar la posición original
+        // Buscar el SelectTransformGizmo en la escena
+        selectTransformGizmo = FindObjectOfType<SelectTransformGizmo>();
+
+        // Verificar si el selectTransformGizmo está asignado correctamente
+        Debug.Log(selectTransformGizmo != null ? "SelectTransformGizmo está asignado." : "SelectTransformGizmo no está asignado.");
     }
 
     /// <summary>
-    /// Inicia el arrastre.
+    /// Configura la cámara principal y las referencias a los componentes `Image` y `RectTransform`.
+    /// </summary>
+    private void Start()
+    {
+        mainCamera = Camera.main; // Obtiene la cámara principal de la escena
+        materialImage = GetComponent<Image>(); // Obtener el componente Image del GameObject
+        rectTransform = GetComponent<RectTransform>(); // Obtiene el componente `RectTransform`, que se utiliza para modificar posición, escala, etc.
+
+        // Guarda la escala y la posición originales de la imagen antes del arrastre
+        originalScale = rectTransform.localScale;
+        originalPosition = rectTransform.position; 
+    }
+
+    /// <summary>
+    /// Método que se ejecuta cuando se comienza a arrastrar el material.
     /// </summary>
     public void OnBeginDrag(PointerEventData eventData)
     {
@@ -45,12 +62,12 @@ public class MaterialDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandle
     /// </summary>
     public void OnDrag(PointerEventData eventData)
     {
-        // Hace que el objeto siga al ratón
+        // Actualiza la posición de la imagen para que siga el cursor del ratón durante el arrastre
         rectTransform.position = eventData.position;
     }
 
-    /// <summary>
-    /// Al finalizar el arrastre, se aplica el nuevo material si se suelta sobre el objeto.
+    // <summary>
+    /// Método que se ejecuta al finalizar el arrastre, y aplica el material si es posible.
     /// </summary>
     public void OnEndDrag(PointerEventData eventData)
     {
@@ -67,62 +84,103 @@ public class MaterialDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandle
             // Restablece la posición original
             rectTransform.position = originalPosition;
         }
-
-        RaycastHit hit;
-        Ray ray = mainCamera.ScreenPointToRay(eventData.position);
-
-        if (Physics.Raycast(ray, out hit) && materialToApply != null)
+        // Lanza un rayo desde la posición del ratón para detectar si golpea un objeto
+        Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+        if (Physics.Raycast(ray, out RaycastHit hit))
         {
+            // Aplica el material a la jerarquía del objeto o a sus MeshRenderers
             ApplyMaterialToHierarchyOrMeshRenderer(hit.transform, materialToApply);
+
+            // Comunicar a SelectTransformGizmo que se ha aplicado un material al objeto seleccionado
+            if (selectTransformGizmo != null && selectTransformGizmo.GetCurrentSelection() == hit.transform)
+            {
+                // Llama a un método en SelectTransformGizmo que maneje la actualización de materiales
+                selectTransformGizmo.OnMaterialApplied(hit.transform, materialToApply);
+            }
         }
     }
 
     /// <summary>
-    /// Aplica el material a todos los Renderers en la jerarquía del objeto transform
-    /// o a todos los subíndices del MeshRenderer si no tiene hijos.
-    /// Excepto si el objeto tiene el tag "Floor".
+    /// Aplica el material a todos los `MeshRenderers` del padre dentro de la jerarquía del objeto `Transform`.
+    /// Si el objeto no tiene hijos, aplica el material a todos los subíndices del `MeshRenderer`.
+    /// Excluye los objetos que tienen el tag "Floor", para los cuales no se aplica el material.
     /// </summary>
-    /// <param name="parent">Transform del objeto padre.</param>
-    /// <param name="material">Material a aplicar.</param>
-    private void ApplyMaterialToHierarchyOrMeshRenderer(Transform parent, Material material)
+    /// <param name="target">El objeto `Transform` objetivo al cual se le aplicará el material.</param>
+    /// <param name="material">El material que se aplicará.</param>
+    private void ApplyMaterialToHierarchyOrMeshRenderer(Transform target, Material material)
     {
         // Verifica si el objeto tiene el tag "Floor" antes de aplicar el material
-        if (parent.CompareTag("Floor"))
+        if (target.CompareTag("Floor"))
         {
             return; // No aplica el material si el objeto tiene el tag "Floor"
         }
 
-        Renderer parentRenderer = parent.GetComponent<Renderer>();
+        // Aplica el material a todos los MeshRenderers del objeto y sus hijos
+        MeshRenderer[] renderers = target.GetComponentsInChildren<MeshRenderer>();
 
-        // Si el objeto no tiene hijos pero tiene un MeshRenderer, aplica el material a todos sus subíndices
-        if (parent.childCount == 0 && parentRenderer != null && parentRenderer.materials.Length > 1)
+        foreach (MeshRenderer renderer in renderers) 
         {
-            ApplyMaterialToAllSubMaterials(parentRenderer, material);
-        }
-        else
-        {
-            // Aplica el material al Renderer del objeto actual si existe
-            if (parentRenderer != null)
+            // Verifica si el objeto está seleccionado
+            bool isSelected = selectTransformGizmo != null && selectTransformGizmo.GetCurrentSelection() == target;
+
+            // Obtener los materiales actuales
+            Material[] currentMaterials = renderer.materials;
+
+            // Si el objeto está seleccionado, se reemplazan todos los materiales menos el último
+            if (isSelected)
             {
-                parentRenderer.material = material;
+                int materialCount = currentMaterials.Length;
+
+                // Si hay más de un material, se reserva el último para el material de selección
+                if (materialCount > 1)
+                {
+                    // Crear un nuevo array de materiales que conserve el último material (de selección)
+                    Material[] newMaterials = new Material[materialCount];
+
+                    // Reemplazar todos los materiales excepto el último
+                    for (int i = 0; i < materialCount - 1; i++)
+                    {
+                        newMaterials[i] = material;
+                    }
+
+                    // Mantener el último material intacto (el de selección)
+                    newMaterials[materialCount - 1] = currentMaterials[materialCount - 1];
+
+                    // Aplicar los nuevos materiales al MeshRenderer
+                    renderer.materials = newMaterials;
+                }
+                else
+                {
+                    // Si solo hay un material, lo reemplaza por completo
+                    renderer.material = material;
+                }
+
+                Debug.Log("Material aplicado al objeto seleccionado, manteniendo el material de selección.");
             }
-
-            // Recorre todos los hijos y aplica el material
-            foreach (Transform child in parent)
+            else
             {
-                ApplyMaterialToHierarchyOrMeshRenderer(child, material);
+                // Si el objeto no está seleccionado, reemplazar todos los materiales normalmente
+                for (int i = 0; i < currentMaterials.Length; i++)
+                {
+                    currentMaterials[i] = material;
+                }
+
+                renderer.materials = currentMaterials;
+
+                Debug.Log("Material aplicado al objeto no seleccionado.");
             }
         }
     }
 
     /// <summary>
-    /// Aplica el material a todos los subíndices del MeshRenderer del objeto.
+    /// Reemplaza todos los submateriales de un solo `MeshRenderer` con un nuevo material.
     /// </summary>
-    /// <param name="renderer">El MeshRenderer del objeto objetivo.</param>
-    /// <param name="material">El material a aplicar.</param>
+    /// <param name="renderer">El `MeshRenderer` objetivo.</param>
+    /// <param name="material">El nuevo material que se aplicará a todos los subíndices.</param>
     private void ApplyMaterialToAllSubMaterials(Renderer renderer, Material material)
     {
-        Material[] materials = renderer.materials; // Obtener todos los submateriales
+        Material[] materials = renderer.materials; // Obtiene todos los submateriales del `MeshRenderer`
+
         for (int i = 0; i < materials.Length; i++)
         {
             materials[i] = material; // Reemplazar cada submaterial con el nuevo material

--- a/Visualizer/Assets/Scripts/SelectTransformGizmo.cs
+++ b/Visualizer/Assets/Scripts/SelectTransformGizmo.cs
@@ -250,11 +250,11 @@ public class SelectTransformGizmo : MonoBehaviour
         }
     }
 
-    // <summary>
+    /// <summary>
     /// Este método se invoca para aplicar un nuevo material a un objeto seleccionado.
     /// Si el objeto en cuestión es el actualmente seleccionado, actualiza su material
     /// en el diccionario de materiales originales.
-    ///
+    /// 
     /// <param name="target">El objeto `Transform` al que se le aplica el nuevo material.</param>
     /// <param name="newMaterial">El nuevo material que se aplicará al objeto.</param>
     /// </summary>
@@ -277,16 +277,27 @@ public class SelectTransformGizmo : MonoBehaviour
                     // Actualiza el array de materiales originales para este renderer
                     Material[] originalMaterials = originalMaterialsSelection[renderer.transform];
 
-                    // Si el número de materiales no coincide, crea un nuevo array con el tamaño adecuado
-                    if (originalMaterials.Length != renderer.materials.Length)
+                    // Crear un nuevo array de materiales si el renderer tiene más de un material
+                    if (renderer.materials.Length > 1)
                     {
-                        originalMaterialsSelection[renderer.transform] = new Material[renderer.materials.Length];
-                    }
+                        // Crear un nuevo array de materiales con un tamaño reducido
+                        Material[] newMaterialsArray = new Material[renderer.materials.Length - 1];
 
-                    // Actualiza los materiales originales con el nuevo material
-                    for (int i = 0; i < renderer.materials.Length; i++)
+                        // Copiar todos los materiales excepto el último
+                        for (int i = 0; i < newMaterialsArray.Length; i++)
+                        {
+                            newMaterialsArray[i] = renderer.materials[i];
+                        }
+
+                        // Asignar el nuevo array al MeshRenderer
+                        renderer.materials = newMaterialsArray;
+
+                        // Actualiza el array de materiales originales en el diccionario
+                        originalMaterialsSelection[renderer.transform] = newMaterialsArray; // Actualiza el diccionario con el nuevo array
+                    }
+                    else
                     {
-                        originalMaterialsSelection[renderer.transform][i] = newMaterial;
+                        Debug.LogWarning("El MeshRenderer tiene sólo un material, no se puede eliminar el último.");
                     }
                 }
                 else
@@ -295,14 +306,12 @@ public class SelectTransformGizmo : MonoBehaviour
                     originalMaterialsSelection.Add(renderer.transform, new Material[renderer.materials.Length]);
 
                     // Inicializa con el nuevo material aplicado
-                    for (int i = 0; i < renderer.materials.Length; i++)
-                    {
-                        originalMaterialsSelection[renderer.transform][i] = newMaterial;
-                    }
+                    originalMaterialsSelection[renderer.transform][0] = newMaterial; // Asigna el nuevo material
                 }
             }
         }
     }
+
     /// <summary>
     /// Maneja el cambio de selección en la jerarquía.
     /// </summary>

--- a/Visualizer/Assets/Thirdparty/RuntimeGizmo/Scripts/RuntimeTransformHandle.cs
+++ b/Visualizer/Assets/Thirdparty/RuntimeGizmo/Scripts/RuntimeTransformHandle.cs
@@ -67,7 +67,7 @@ namespace RuntimeHandle
             }
         }
 
-        // Método auxiliar para asignar un tag solo a los hijos del objeto
+        // Método para asignar un tag solo a los hijos del objeto
         void AssignTagToChildren(GameObject parent, string tag)
         {
             // Obtener todos los hijos del objeto padre

--- a/Visualizer/Assets/Thirdparty/RuntimeGizmo/Scripts/RuntimeTransformHandle.cs
+++ b/Visualizer/Assets/Thirdparty/RuntimeGizmo/Scripts/RuntimeTransformHandle.cs
@@ -54,29 +54,29 @@ namespace RuntimeHandle
             {
                 case HandleType.POSITION:
                     _positionHandle = gameObject.AddComponent<PositionHandle>().Initialize(this);
-                    AssignTagToChildren(gameObject, "Floor"); // Asignar tag solo a los hijos para el gizmo de posición
+                    AssignTagToChildren(gameObject, "Floor"); // Assign tag only to children for position gizmo
                     break;
                 case HandleType.ROTATION:
                     _rotationHandle = gameObject.AddComponent<RotationHandle>().Initialize(this);
-                    AssignTagToChildren(gameObject, "Floor"); // Asignar tag solo a los hijos para el gizmo de rotación
+                    AssignTagToChildren(gameObject, "Floor"); // Assign tag only to children for rotation gizmo
                     break;
                 case HandleType.SCALE:
                     _scaleHandle = gameObject.AddComponent<ScaleHandle>().Initialize(this);
-                    AssignTagToChildren(gameObject, "Floor"); // Asignar tag solo a los hijos para el gizmo de escala
+                    AssignTagToChildren(gameObject, "Floor"); // Assign tag only to children for scale gizmo
                     break;
             }
         }
 
-        // Método para asignar un tag solo a los hijos del objeto
+        // Method to assign a tag only to the children of the object
         void AssignTagToChildren(GameObject parent, string tag)
         {
-            // Obtener todos los hijos del objeto padre
+            // Get all children of the parent object
             Transform[] children = parent.GetComponentsInChildren<Transform>();
 
-            // Asignar el tag solo a los hijos, ignorando el objeto padre
+            // Assign the tag only to the children, ignoring the parent object
             foreach (Transform child in children)
             {
-                if (child != parent.transform) // Ignorar el objeto padre
+                if (child != parent.transform) // Ignore the parent object
                 {
                     child.gameObject.tag = tag;
                 }

--- a/Visualizer/Assets/Thirdparty/RuntimeGizmo/Scripts/RuntimeTransformHandle.cs
+++ b/Visualizer/Assets/Thirdparty/RuntimeGizmo/Scripts/RuntimeTransformHandle.cs
@@ -54,13 +54,32 @@ namespace RuntimeHandle
             {
                 case HandleType.POSITION:
                     _positionHandle = gameObject.AddComponent<PositionHandle>().Initialize(this);
+                    AssignTagToChildren(gameObject, "Floor"); // Asignar tag solo a los hijos para el gizmo de posición
                     break;
                 case HandleType.ROTATION:
                     _rotationHandle = gameObject.AddComponent<RotationHandle>().Initialize(this);
+                    AssignTagToChildren(gameObject, "Floor"); // Asignar tag solo a los hijos para el gizmo de rotación
                     break;
                 case HandleType.SCALE:
                     _scaleHandle = gameObject.AddComponent<ScaleHandle>().Initialize(this);
+                    AssignTagToChildren(gameObject, "Floor"); // Asignar tag solo a los hijos para el gizmo de escala
                     break;
+            }
+        }
+
+        // Método auxiliar para asignar un tag solo a los hijos del objeto
+        void AssignTagToChildren(GameObject parent, string tag)
+        {
+            // Obtener todos los hijos del objeto padre
+            Transform[] children = parent.GetComponentsInChildren<Transform>();
+
+            // Asignar el tag solo a los hijos, ignorando el objeto padre
+            foreach (Transform child in children)
+            {
+                if (child != parent.transform) // Ignorar el objeto padre
+                {
+                    child.gameObject.tag = tag;
+                }
             }
         }
 


### PR DESCRIPTION
Se solucionaron los siguientes Bugs:

1-El D&D funciona con modelos que están siendo al mismo tiempo seleccionados por SelectTransformGizmo. Esto se solucionó actualizando el Dictionary en SlelectTransformGizmo. La función del Dictionary es restaurar los materiales de un modelo al dejar de seleccionarlo, pero al actualizarlo al momento de añadir un nuevo material por medio de D&D no los restaura a los materiales originales.

2- El material de selección no ocasiona ningún Bug y funciona de manera correcta en conjunto con modelos que se les aplica un material y al mismo tiempo están siendo seleccionados por SelecTransformGizmo. Al modificar el Dictionary se rompía el material de selección, ocasionando algunos bugs, pero se solucionó manejando las partes donde el material de selección actúa en conjunto con el D&D.

3-Los Gizmos de selección, rotación y escala no se ven afectados por el D&D de materiales. Esto se solucionó de añadiendo una restricción en el script que spawmea el GameObject que maneja la selección, rotación y escala.

4-La versión funcional de SelectTransformGizmo funciona junto con los cambios hechos sin romper ninguna funcionalidad. Esto se logró combinando los cambios anteriormente mencionados junto con la versión funcional de SelectTransformGizmo ya que antes se rompían algunas funcionalidades.